### PR TITLE
Add support for Amazon Linux

### DIFF
--- a/logic/amazon.js
+++ b/logic/amazon.js
@@ -1,0 +1,8 @@
+var releaseRegex = /release (.*)/
+
+module.exports = function amazonCustomLogic(os,file,cb) {
+    var release = file.match(releaseRegex)
+    if (release && release.length === 2) os.release = release[1]
+    cb(null,os)
+};
+

--- a/os.json
+++ b/os.json
@@ -47,5 +47,6 @@
   "/etc/UnitedLinux-release" : ["UnitedLinux"],
   "/etc/va-release" : ["VA-Linux/RH-VALE"],
   "/etc/yellowdog-release" : ["Yellow Dog"],
-  "/etc/alpine-release": ["Alpine Linux"]
+  "/etc/alpine-release": ["Alpine Linux"],
+  "/etc/system-release": ["Amazon Linux"]
 }

--- a/tests/mockdata.json
+++ b/tests/mockdata.json
@@ -21,5 +21,6 @@
 , { "desc": "SUSE Linux", "platform": "linux", "file": { "/etc/SuSE-release": "SUSE Linux Enterprise Server 11 (x86_64)\nVERSION = 11\nPATCHLEVEL = 4\n" },    "expected": { "dist": "SUSE Linux", "os": "linux", "release": "11" }    }
 
 , { "desc": "Alpine Linux", "platform": "linux", "file": { "/etc/alpine-release": "3.3\n" },    "expected": { "dist": "Alpine Linux", "os": "linux", "release": "3.3" }    }
+, { "desc": "Amazon Linux", "platform": "linux", "file": { "/etc/system-release": "Amazon Linux AMI release 2016.03"}, "expected": {"dist": "Amazon Linux", "os": "linux", "release": "2016.03"}}
 
 ]


### PR DESCRIPTION
Hi @retrohacker 

I've implemented check of Amazon Linux OS release. Please, take a look.

Also, I've noticed there is a mixed up Actual and Expected values in mocktests.js. This leads to wrong message in failed tests. I didn't include any change related to this in PR, can submit it later.

Thanks,