### PR TITLE
Add postinstall script to create symlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "node tests/mocktests.js",
     "posttest": "standard",
     "integration": "node tests/runTest.js",
-    "standard-fix": "standard --fix"
+    "standard-fix": "standard --fix",
+    "postinstall": "node postinstall.js"
   },
   "repository": {
     "type": "git",

--- a/postinstall.js
+++ b/postinstall.js
@@ -23,7 +23,7 @@ Object.keys(symlinks).forEach(function (key) {
     })
     return
   }
-  fs.symlink(path.join(__dirname, symlinks[key]), path.join(__dirname, key), function (err) {
+  fs.symlink(path.join('../', symlinks[key]), path.join(__dirname, key), function (err) {
     if (err && err.code !== 'EEXIST') {
       console.error(err)
     }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const platform = require('os').platform();
+const symlinks = require('./symlinks.json');
+
+// Copy the files on Windows since it has bad symlink support
+const COPY_FILES = (platform === "win32");
+
+Object.keys(symlinks).forEach(function(key) {
+  if (COPY_FILES) {
+    fs.readFile(__dirname + '/' + symlinks[key], function (err, data) {
+      // Log the error and move on...
+      if (err) {
+        console.error(err);
+        return;
+      }
+
+      fs.writeFile(__dirname + '/' + key, data, function(err) {
+        if (err) {
+          console.error(err);
+          return;
+        }
+      });
+    });
+    return;
+  }
+  fs.symlink(__dirname + '/' + symlinks[key], __dirname + '/' + key, function(err) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+  });
+});

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const fs = require('fs')
 const platform = require('os').platform()
 const symlinks = require('./symlinks.json')
@@ -7,14 +8,14 @@ const COPY_FILES = (platform === 'win32')
 
 Object.keys(symlinks).forEach(function (key) {
   if (COPY_FILES) {
-    fs.readFile(__dirname + '/' + symlinks[key], function (err, data) {
+    fs.readFile(path.join(__dirname, symlinks[key]), function (err, data) {
       // Log the error and move on...
       if (err) {
         console.error(err)
         return
       }
 
-      fs.writeFile(__dirname + '/' + key, data, function (err) {
+      fs.writeFile(path.join(__dirname, key), data, function (err) {
         if (err) {
           console.error(err)
         }
@@ -22,8 +23,8 @@ Object.keys(symlinks).forEach(function (key) {
     })
     return
   }
-  fs.symlink(__dirname + '/' + symlinks[key], __dirname + '/' + key, function (err) {
-    if (err) {
+  fs.symlink(path.join(__dirname, symlinks[key]), path.join(__dirname, key), function (err) {
+    if (err && err.code !== 'EEXIST') {
       console.error(err)
     }
   })

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,32 +1,30 @@
-const fs = require('fs');
-const platform = require('os').platform();
-const symlinks = require('./symlinks.json');
+const fs = require('fs')
+const platform = require('os').platform()
+const symlinks = require('./symlinks.json')
 
 // Copy the files on Windows since it has bad symlink support
-const COPY_FILES = (platform === "win32");
+const COPY_FILES = (platform === 'win32')
 
-Object.keys(symlinks).forEach(function(key) {
+Object.keys(symlinks).forEach(function (key) {
   if (COPY_FILES) {
     fs.readFile(__dirname + '/' + symlinks[key], function (err, data) {
       // Log the error and move on...
       if (err) {
-        console.error(err);
-        return;
+        console.error(err)
+        return
       }
 
-      fs.writeFile(__dirname + '/' + key, data, function(err) {
+      fs.writeFile(__dirname + '/' + key, data, function (err) {
         if (err) {
-          console.error(err);
-          return;
+          console.error(err)
         }
-      });
-    });
-    return;
+      })
+    })
+    return
   }
-  fs.symlink(__dirname + '/' + symlinks[key], __dirname + '/' + key, function(err) {
+  fs.symlink(__dirname + '/' + symlinks[key], __dirname + '/' + key, function (err) {
     if (err) {
-      console.error(err);
-      return;
+      console.error(err)
     }
-  });
-});
+  })
+})

--- a/postinstall.js
+++ b/postinstall.js
@@ -23,7 +23,8 @@ Object.keys(symlinks).forEach(function (key) {
     })
     return
   }
-  fs.symlink(path.join('../', symlinks[key]), path.join(__dirname, key), function (err) {
+  const relativePath = path.relative(path.dirname(key), path.join(__dirname, symlinks[key]))
+  fs.symlink(relativePath, path.join(__dirname, key), function (err) {
     if (err && err.code !== 'EEXIST') {
       console.error(err)
     }

--- a/symlinks.json
+++ b/symlinks.json
@@ -1,0 +1,5 @@
+{
+  "logic/arch.js": "logic/ubuntu.js",
+  "logic/mint.js": "logic/ubuntu.js",
+  "logic/raspbian.js": "logic/debian.js"
+}


### PR DESCRIPTION
I noticed that when installing from npm the symlinks in the logic folder weren't present. I believe this is a deliberate decision by npm?

I've added a postinstall script to re-create them.

Note: You might want to merge my other pull request (#61) first as I've added a symlink for raspbian in this commit to be consistent with that pull request.