### PR TITLE
Add basic NixOS recognition

### DIFF
--- a/os.json
+++ b/os.json
@@ -7,6 +7,7 @@
   "/etc/debian_version" : ["Debian"],
   "/etc/debian_release" : ["Debian"],
   "/etc/os-release": ["Raspbian"],
+  "/etc/NIXOS": ["NixOS"],
   "/etc/annvix-release" : ["Annvix"],
   "/etc/arch-release" : ["Arch Linux"],
   "/etc/arklinux-release" : ["Arklinux"],

--- a/tests/mockdata.json
+++ b/tests/mockdata.json
@@ -25,4 +25,5 @@
 , { "desc": "Linux Mint", "platform": "linux", "file": { "/etc/lsb-release": "DISTRIB_ID=LinuxMint\nDISTRIB_RELEASE=18\nDISTRIB_CODENAME=sarah\nDISTRIB_DESCRIPTION=\"Linux Mint 18 Sarah\""}, "expected": {"dist": "Linux Mint", "os": "linux", "codename": "sarah", "release": "18"}}
 
 , { "desc": "Raspbian 8", "platform": "linux", "file": { "/etc/os-release": "PRETTY_NAME=\"Raspbian GNU/Linux 8 (jessie)\"\nNAME=\"Raspbian GNU/Linux\"\nVERSION_ID=\"8\"\nVERSION=\"8 (jessie)\"\nID=raspbian\nHOME_URL=\"http://www.raspbian.org/\"\nSUPPORT_URL=\"http://www.raspbian.org/RaspbianForums\"\nBUG_REPORT_URL=\"http://www.raspbian.org/RaspbianBugs\"" },        "expected": { "codename": "jessie", "dist": "Raspbian", "os": "linux", "release": "8" }  }
+, { "desc": "NixOS", "platform": "linux", "file": { "/etc/NIXOS": " " }, "expected": { "dist": "NixOS", "os": "linux" } }
 ]


### PR DESCRIPTION
Fix #65 

The file `/etc/NIXOS` is empty (size 0), but unfortunately the mock has to have a space, otherwise the test fails.

This is one way NixOS recognises itself internally:
https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/activation/switch-to-configuration.pl#L37-L38

The other file is `/etc/os-release`, which contains more data but as soon as I tried adding NixOS to the `/etc/os-release` entry in `os.json`, the Raspbian tests failed and I don't currently have the time to look into it. I can try again later if that would be useful.
```
NAME=NixOS
ID=nixos
VERSION="17.09.2610.d83c8080d1e (Hummingbird)"
VERSION_CODENAME=hummingbird
VERSION_ID="17.09.2610.d83c8080d1e"
PRETTY_NAME="NixOS 17.09.2610.d83c8080d1e (Hummingbird)"
HOME_URL="https://nixos.org/"
SUPPORT_URL="https://nixos.org/nixos/support.html"
BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
```

`lsb_release` does not recognise anything as of v1.4.