### PR TITLE
Invalidating the cache correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-    - "0.12"
-    - "0.10"
-    - "4"
-    - "5"
     - "6"
+    - "8"
+    - "10"
+    - "12"
 sudo: false

--- a/tests/mocktests.js
+++ b/tests/mocktests.js
@@ -26,7 +26,7 @@ fs.readFile = function (file, enc, callback) {
 mockdata.forEach(function (data) {
   test('test ' + data.desc, function (t) {
     // reload each time to avoid internal caching
-    require.cache[require.resolve('../')] = null
+    delete require.cache[require.resolve('../')]
     var getos = require('../')
 
     currentData = data


### PR DESCRIPTION
I saw that in Travis CI tests didn't pass. I think the problem was in invalidating cache using null.
I request this change in fork ecgan/getos by PR1[https://github.com/ecgan/getos/pull/1].