### PR TITLE
Use require as supported by ncc asset handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,7 @@ function getName (candidate) {
  * Loads a custom logic module to populate additional distribution information
  */
 function customLogic (os, name, file, cb) {
-  var logic = './logic/' + name + '.js'
-  try { require(logic)(os, file, cb) } catch (e) { cb(null, os) }
+  try { require(`./logic/${name}.js`)(os, file, cb) } catch (e) { cb(null, os) }
 }
 
 /**


### PR DESCRIPTION
By moving the path of the dynamically loaded logic files into the require we let the asset relocator used in [@zeit/ncc]( https://github.com/zeit/ncc) pack the files successfully (see https://github.com/zeit/webpack-asset-relocator-loader/issues/36).
Fixes the issue behind #104.